### PR TITLE
Add support for Corretto 17

### DIFF
--- a/bin/corretto.bash
+++ b/bin/corretto.bash
@@ -163,9 +163,10 @@ function download {
 
 download_github_releases 'corretto' 'corretto-8' "${TEMP_DIR}/releases-corretto-8.json"
 download_github_releases 'corretto' 'corretto-11' "${TEMP_DIR}/releases-corretto-11.json"
+download_github_releases 'corretto' 'corretto-11' "${TEMP_DIR}/releases-corretto-17.json"
 download_github_releases 'corretto' 'corretto-jdk' "${TEMP_DIR}/releases-corretto-jdk.json"
 
-jq -s 'add' "${TEMP_DIR}/releases-corretto-8.json" "${TEMP_DIR}/releases-corretto-11.json" "${TEMP_DIR}/releases-corretto-jdk.json" > "${TEMP_DIR}/releases-corretto.json"
+jq -s 'add' "${TEMP_DIR}/releases-corretto-8.json" "${TEMP_DIR}/releases-corretto-11.json"  "${TEMP_DIR}/releases-corretto-17.json" "${TEMP_DIR}/releases-corretto-jdk.json" > "${TEMP_DIR}/releases-corretto.json"
 
 for CORRETTO_VERSION in $(jq -r '.[].tag_name' "${TEMP_DIR}/releases-corretto.json" | sort -V)
 do

--- a/bin/corretto.bash
+++ b/bin/corretto.bash
@@ -163,7 +163,7 @@ function download {
 
 download_github_releases 'corretto' 'corretto-8' "${TEMP_DIR}/releases-corretto-8.json"
 download_github_releases 'corretto' 'corretto-11' "${TEMP_DIR}/releases-corretto-11.json"
-download_github_releases 'corretto' 'corretto-11' "${TEMP_DIR}/releases-corretto-17.json"
+download_github_releases 'corretto' 'corretto-17' "${TEMP_DIR}/releases-corretto-17.json"
 download_github_releases 'corretto' 'corretto-jdk' "${TEMP_DIR}/releases-corretto-jdk.json"
 
 jq -s 'add' "${TEMP_DIR}/releases-corretto-8.json" "${TEMP_DIR}/releases-corretto-11.json"  "${TEMP_DIR}/releases-corretto-17.json" "${TEMP_DIR}/releases-corretto-jdk.json" > "${TEMP_DIR}/releases-corretto.json"


### PR DESCRIPTION
The proposed change should allow to list corretto 17 releases.

However, with a growing number of LTS, we might see a growing number of repository to crawl. The current approach in the script will not scale.