### PR TITLE
Corretto aarch64 builds weren't scanned

### DIFF
--- a/bin/corretto.bash
+++ b/bin/corretto.bash
@@ -52,7 +52,7 @@ function get_archs_for_os {
 		;;
 	'alpine-linux') echo 'x64'
 		;;
-	'macosx') echo 'x64'
+	'macosx') echo 'x64' 'aarch64'
 		;;
 	'windows') echo 'x64' 'x86'
 		;;


### PR DESCRIPTION
This change simply adds `aarch64` to macos distributions.
At this date only corretto 17 ships an aarch64 architecture.


