### PR TITLE
Add support for Oracle JDK 20. Add Oracle JDK to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Supported OpenJDK distributions:
 * [Mandrel](https://github.com/graalvm/mandrel)
 * [Microsoft OpenJDK](https://www.microsoft.com/openjdk)
 * [OpenJDK](https://jdk.java.net/)
+* [Oracle JDK](https://www.oracle.com/java/)
 * [SapMachine](https://sap.github.io/SapMachine/)
 * [Tencent Kona](https://cloud.tencent.com/document/product/1149)
 * [Trava OpenJDK](https://github.com/TravaOpenJDK/)

--- a/bin/oracle.bash
+++ b/bin/oracle.bash
@@ -109,7 +109,7 @@ function download_and_parse {
 	done
 }
 
-for version in 17 18 19
+for version in 17 18 19 20
 do
 	download_and_parse "$version"
 done


### PR DESCRIPTION
- Add support for Oracle JDK 20
- Add Oracle JDK to readme
