### PR TITLE
Add support for GraalVM new release model

### DIFF
--- a/bin/graalvm-ce.bash
+++ b/bin/graalvm-ce.bash
@@ -34,6 +34,7 @@ function download {
 	then
 		echo "Skipping ${filename}"
 	else
+		# Prior graalvm 23         : graalvm-ce-java17-darwin-amd64-22.3.2.tar.gz
 		# shellcheck disable=SC2016
 		local regex='s/^graalvm-ce-(?:complete-)?java([0-9]{1,2})-(linux|darwin|windows)-(aarch64|amd64)-([0-9+.]{2,})\.(zip|tar\.gz)$/JAVA_VERSION="$1" OS="$2" ARCH="$3" VERSION="$4" EXT="$5"/g'
 

--- a/bin/graalvm-community.bash
+++ b/bin/graalvm-community.bash
@@ -34,8 +34,8 @@ function download {
 	then
 		echo "Skipping ${filename}"
 	else
-	  # Starting from graalvm 23 : graalvm-community-jdk-17.0.7_macos-aarch64_bin.tar.gz
-	  #                            graalvm-community-jdk-17.0.7_linux-x64_bin.tar.gz
+		# Starting from graalvm 23 : graalvm-community-jdk-17.0.7_macos-aarch64_bin.tar.gz
+		#                            graalvm-community-jdk-17.0.7_linux-x64_bin.tar.gz
 		# shellcheck disable=SC2016
 		local regex='s/^graalvm-community-jdk-([0-9]{1,2}\.[0-9]{1}\.[0-9]{1,3})_(linux|macos|windows)-(aarch64|x64)_bin\.(zip|tar\.gz)$/JAVA_VERSION="$1" OS="$2" ARCH="$3" EXT="$4"/g'
 

--- a/bin/graalvm-community.bash
+++ b/bin/graalvm-community.bash
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -e
+set -Euo pipefail
+
+TEMP_DIR=$(mktemp -d)
+trap 'rm -rf ${TEMP_DIR}' EXIT
+
+if [[ "$#" -lt 2 ]]
+then
+	echo "Usage: ${0} metadata-directory checksum-directory"
+	exit 1
+fi
+
+# shellcheck source=bin/functions.bash
+source "$(dirname "${0}")/functions.bash"
+
+VENDOR='graalvm-community'
+METADATA_DIR="${1}/${VENDOR}"
+CHECKSUM_DIR="${2}/${VENDOR}"
+
+ensure_directory "${METADATA_DIR}"
+ensure_directory "${CHECKSUM_DIR}"
+
+function download {
+	local tag_name="${1}"
+	local asset_name="${2}"
+	local filename="${asset_name}"
+
+	local url="https://github.com/graalvm/graalvm-ce-builds/releases/download/${tag_name}/${asset_name}"
+	local metadata_file="${METADATA_DIR}/${filename}.json"
+	local archive="${TEMP_DIR}/${filename}"
+
+	if [[ -f "${metadata_file}" ]]
+	then
+		echo "Skipping ${filename}"
+	else
+	  # Starting from graalvm 23 : graalvm-community-jdk-17.0.7_macos-aarch64_bin.tar.gz
+	  #                            graalvm-community-jdk-17.0.7_linux-x64_bin.tar.gz
+		# shellcheck disable=SC2016
+		local regex='s/^graalvm-community-jdk-([0-9]{1,2}\.[0-9]{1}\.[0-9]{1,3})_(linux|macos|windows)-(aarch64|x64)_bin\.(zip|tar\.gz)$/JAVA_VERSION="$1" OS="$2" ARCH="$3" EXT="$4"/g'
+
+		local JAVA_VERSION=""
+		local OS=""
+		local ARCH=""
+		local VERSION=""
+		local EXT=""
+
+		# Parse meta-data from file name
+		eval "$(echo "${asset_name}" | perl -pe "${regex}")"
+
+		download_file "${url}" "${archive}" || return 1
+
+		local json
+		json="$(metadata_json \
+			"${VENDOR}" \
+			"${filename}" \
+			'ga' \
+			"${VERSION}+java${JAVA_VERSION}" \
+			"${JAVA_VERSION}" \
+			'graalvm' \
+			"$(normalize_os "${OS}")" \
+			"$(normalize_arch "${ARCH}")" \
+			"${EXT}" \
+			'jdk' \
+			'' \
+			"${url}" \
+			"$(hash_file 'md5' "${archive}" "${CHECKSUM_DIR}")" \
+			"$(hash_file 'sha1' "${archive}" "${CHECKSUM_DIR}")" \
+			"$(hash_file 'sha256' "${archive}" "${CHECKSUM_DIR}")" \
+			"$(hash_file 'sha512' "${archive}" "${CHECKSUM_DIR}")" \
+			"$(file_size "${archive}")" \
+			"${filename}"
+		)"
+
+		echo "${json}" > "${metadata_file}"
+		rm -f "${archive}"
+	fi
+}
+
+download_github_releases 'graalvm' 'graalvm-ce-builds' "${TEMP_DIR}/releases-graalvm-community.json"
+
+versions=$(jq -r '.[].tag_name' "${TEMP_DIR}/releases-graalvm-community.json" | sort -V | grep "^jdk")
+for version in ${versions}
+do
+	assets=$(jq -r  ".[] | select(.tag_name == \"${version}\") | .assets[].name | select(startswith(\"graalvm-community\")) | select(endswith(\"tar.gz\") or endswith(\"zip\"))" "${TEMP_DIR}/releases-graalvm-community.json")
+	for asset in ${assets}
+	do
+		download "${version}" "${asset}" || echo "Cannot download ${asset}"
+	done
+done
+
+jq -s -S . "${METADATA_DIR}"/graalvm-community-*.json > "${METADATA_DIR}/all.json"

--- a/bin/graalvm-community.bash
+++ b/bin/graalvm-community.bash
@@ -42,7 +42,6 @@ function download {
 		local JAVA_VERSION=""
 		local OS=""
 		local ARCH=""
-		local VERSION=""
 		local EXT=""
 
 		# Parse meta-data from file name
@@ -55,7 +54,7 @@ function download {
 			"${VENDOR}" \
 			"${filename}" \
 			'ga' \
-			"${VERSION}+java${JAVA_VERSION}" \
+			"${JAVA_VERSION}" \
 			"${JAVA_VERSION}" \
 			'graalvm' \
 			"$(normalize_os "${OS}")" \

--- a/bin/update.bash
+++ b/bin/update.bash
@@ -31,7 +31,7 @@ vendors=(
 	"$(cmd 'semeru16')"
 	"$(cmd 'semeru17')"
 	"$(cmd 'graalvm-legacy')"
-	"$(cmd 'graalvm')"
+	"$(cmd 'graalvm-ce')"
 	"$(cmd 'zulu')"
 	"$(cmd 'sapmachine')"
 	"$(cmd 'liberica')"

--- a/bin/update.bash
+++ b/bin/update.bash
@@ -32,6 +32,7 @@ vendors=(
 	"$(cmd 'semeru17')"
 	"$(cmd 'graalvm-legacy')"
 	"$(cmd 'graalvm-ce')"
+	"$(cmd 'graalvm-community')"
 	"$(cmd 'zulu')"
 	"$(cmd 'sapmachine')"
 	"$(cmd 'liberica')"


### PR DESCRIPTION
GraalVM 23 is not anymore a "version", instead the release model will now follow the latest JDK available.

Up to GraalVM 22.3 we had 
* [GraalVM Community Edition 22.3.2](https://github.com/graalvm/graalvm-ce-builds/releases/tag/vm-22.3.2)

Starting from GraalVM 23
* [GraalVM for JDK 17 Community 17.0.7](https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-17.0.7)
* [GraalVM for JDK 20 Community 20.0.1](https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-20.0.1)

Not mentioning common components that are released under the Graalvm 23, but that are irrelevant here. In order to not confuse consumers by inserting version 17.0.7 and 20.0.1 in the past I suggest to handle the new releases in different section.

So to accommodate the release model change 
* the current graalvm script has been renamed to `graalvm-ce.bash`.
* a new `graalvm-community.bash` has been created with a new vendor `graalvm-community`

Note this PR does not address 
- Mandrel because it doesn't seem to have taken upon the release alignment, there's an actual release for 23 : [Mandrel 23.0.0.0-Final](https://github.com/graalvm/mandrel/releases/tag/mandrel-23.0.0.0-Final)
- Oracle GraalVM distribution which requires different handling, maybe with the friendly urls https://www.oracle.com/java/technologies/jdk-script-friendly-urls/ ?.


I'm not sure I properly tested the new script. Please advise.

----

Source: https://medium.com/graalvm/a-new-graalvm-release-and-new-free-license-4aab483692f5

Source: https://medium.com/graalvm/graalvm-galahad-and-a-new-release-schedule-d081d1031bba

> ## Release Alignment
> Starting with JDK 20 in March 2023, GraalVM will follow the JDK’s six-month release cadence.
> 
> Since its first release, new feature releases of GraalVM Enterprise and Community Editions have followed a three-month cadence whereas, since 2017, new JDK feature releases have followed a six-month cadence. Starting with the JDK 20 release in March of 2023, GraalVM Enterprise and GraalVM Community Editions intend to align with the six-month JDK release cadence. This means there will not be a GraalVM 23.0 release in January 2023 as we transition to the new release model. In addition, starting with JDK 20, GraalVM releases will only support the latest JDK version (just as Oracle OpenJDK releases do). This will simplify the choice of versions and ensure that developers have access to the latest Java features with each GraalVM release.
> 
> As part of this alignment, GraalVM will adopt the JDK’s release numbering scheme based on the supported Java version. To avoid confusion with older releases, new releases will be named GraalVM for JDK <Java version>, with the next release, in March of 2023, expected to be _GraalVM for JDK 20_.

