### PR TITLE
feature: Adds corretto-21 repo

### DIFF
--- a/bin/corretto.bash
+++ b/bin/corretto.bash
@@ -167,6 +167,7 @@ download_github_releases 'corretto' 'corretto-17' "${TEMP_DIR}/releases-corretto
 download_github_releases 'corretto' 'corretto-18' "${TEMP_DIR}/releases-corretto-18.json"
 download_github_releases 'corretto' 'corretto-19' "${TEMP_DIR}/releases-corretto-19.json"
 download_github_releases 'corretto' 'corretto-20' "${TEMP_DIR}/releases-corretto-20.json"
+download_github_releases 'corretto' 'corretto-21' "${TEMP_DIR}/releases-corretto-21.json"
 download_github_releases 'corretto' 'corretto-jdk' "${TEMP_DIR}/releases-corretto-jdk.json"
 
 jq -s 'add' \
@@ -176,6 +177,7 @@ jq -s 'add' \
 	"${TEMP_DIR}/releases-corretto-18.json" \
 	"${TEMP_DIR}/releases-corretto-19.json" \
 	"${TEMP_DIR}/releases-corretto-20.json" \
+ 	"${TEMP_DIR}/releases-corretto-21.json" \
 	"${TEMP_DIR}/releases-corretto-jdk.json" \
 	> "${TEMP_DIR}/releases-corretto.json"
 


### PR DESCRIPTION
At this time I haven't seen public release on the repo, only pre-releases, but given all repo work that way, I'm sure at some point the pre-release (which was the candidate) will eventually be marked a published.

https://github.com/corretto/corretto-21/releases/tag/21.0.0.35.1

<img width="1194" alt="image" src="https://github.com/joschi/java-metadata/assets/803621/905e8b12-9a98-44ea-9e23-db9fcf6a8bac">

https://github.com/corretto/corretto-downloads/blob/e4a73e49c5fd2b0f1630b39239610884fcf74de3/latest_links/indexmap_with_checksum.json#L1597-L1602
```
    "21": {
     "pkg": {
      "checksum": "760d89e954093c43907454120eef3c1f",
      "checksum_sha256": "4a877d133a3c2c524947a53f5f031cb87264c18c97c858acb084bbf8bf4e476c",
      "resource": "/downloads/resources/21.0.0.35.1/amazon-corretto-21.0.0.35.1-macosx-aarch64.pkg"
     },
```

