### PR TITLE
Work around broken parsing in zulu.bash

### DIFF
--- a/bin/zulu.bash
+++ b/bin/zulu.bash
@@ -63,7 +63,10 @@ do
 	METADATA_FILE="${METADATA_DIR}/${ZULU_FILE}.json"
 	ZULU_ARCHIVE="${TEMP_DIR}/${ZULU_FILE}"
 	ZULU_URL="https://static.azul.com/zulu/bin/${ZULU_FILE}"
-	if [[ -f "${METADATA_FILE}" ]]
+	if [[ "${ZULU_FILE}" == *"zre"* ]]
+	then
+	        echo  "Ignoring ${ZULU_FILE}"	    
+	elif [[ -f "${METADATA_FILE}" ]]
 	then
 		echo "Skipping ${ZULU_FILE}"
 	else

--- a/bin/zulu.bash
+++ b/bin/zulu.bash
@@ -65,7 +65,7 @@ do
 	ZULU_URL="https://static.azul.com/zulu/bin/${ZULU_FILE}"
 	if [[ "${ZULU_FILE}" == *"zre"* ]]
 	then
-	        echo  "Ignoring ${ZULU_FILE}"	    
+		echo  "Ignoring ${ZULU_FILE}"	    
 	elif [[ -f "${METADATA_FILE}" ]]
 	then
 		echo "Skipping ${ZULU_FILE}"


### PR DESCRIPTION
There are some entries in the Azul archive that the script does not expect, they are for "JDKs" like `zre9.0.0.15-jre9.0.0-macosx_x64.dmg`. This eventually causes a fatal error, which prevents the script from completing and updating files like `all.json`. This fix just ignores lines that include `zre`.