### PR TITLE
FIX: properly detect JDK vs. JDK for IBM downloads

### DIFF
--- a/bin/ibm.bash
+++ b/bin/ibm.bash
@@ -51,7 +51,7 @@ do
         OS="linux"
         ARCH=$ARCHITECTURE
         ARCHIVE=$(echo "$IBM_FILE" | perl -pe 's#.*\.([^.]+)$#$1#g')
-        if [[ "${IBM_FILE}" = *"jdk"* ]]
+        if [[ "${IBM_FILE}" = *"sdk"* ]]
         then
           IMAGE_TYPE="jdk"
         else


### PR DESCRIPTION
JDK vs JRE was not properly detected based on the IBM filenames

Refs https://github.com/joschi/java-metadata/pull/55