### PR TITLE
Fix #52 - Missing recent Oracle/GraalVM GA versions

### DIFF
--- a/bin/oracle-graalvm.bash
+++ b/bin/oracle-graalvm.bash
@@ -77,7 +77,11 @@ function download_and_parse {
 		then
 			echo "Skipping ${JDK_FILE}"
 		else
-			download_file "${JDK_URL}" "${JDK_ARCHIVE}"
+			if ! download_file "${JDK_URL}" "${JDK_ARCHIVE}";
+			then
+				echo "Failed to download ${JDK_FILE}, skipping"
+				continue
+			fi
 			VERSION=""
 			OS=""
 			ARCH=""

--- a/bin/oracle-graalvm.bash
+++ b/bin/oracle-graalvm.bash
@@ -65,7 +65,7 @@ function download_and_parse {
 
 	for JDK_FILE in ${JDK_FILES} ${JDK_FILES_CURRENT}
 	do
-		if [[ -n "${JDK_FILE}" ]]
+		if [[ -z "${JDK_FILE}" ]]
 		then
 			continue
 		fi

--- a/bin/oracle.bash
+++ b/bin/oracle.bash
@@ -67,7 +67,7 @@ function download_and_parse {
 
 	for JDK_FILE in ${JDK_FILES} ${JDK_FILES_CURRENT}
 	do
-		if [[ -n "${JDK_FILE}" ]]
+		if [[ -z "${JDK_FILE}" ]]
 		then
 			continue
 		fi

--- a/bin/oracle.bash
+++ b/bin/oracle.bash
@@ -79,7 +79,11 @@ function download_and_parse {
 		then
 			echo "Skipping ${JDK_FILE}"
 		else
-			download_file "${JDK_URL}" "${JDK_ARCHIVE}"
+			if ! download_file "${JDK_URL}" "${JDK_ARCHIVE}";
+			then
+				echo "Failed to download ${JDK_FILE}, skipping"
+				continue
+			fi
 			VERSION=""
 			OS=""
 			ARCH=""


### PR DESCRIPTION
Oracle JDK and GraalVM JDK GA versions haven't been updated since this commit https://github.com/joschi/java-metadata/commit/490a09c342f9042bd0d12948b5c6c36a313d67e5
If I understand the code correctly, I think it's just a simple `if` conditional bug.
I also needed to add a check if the download couldn't succeed due to a non-existing URL. This is specifically for Oracle 17.0.3 and GraalVM 17.0.3 - for some reason this version isn't available via the Archive links - Oracle does mention about it here at the end of this page: https://www.oracle.com/java/technologies/jdk-script-friendly-urls/

This fixes https://github.com/joschi/java-metadata/issues/52