### PR TITLE
Fix Oracle metadata generation

### DIFF
--- a/bin/oracle.bash
+++ b/bin/oracle.bash
@@ -98,6 +98,13 @@ download_file "https://java.oraclecloud.com/javaVersions" "${TEMP_DIR}/latest-ve
 for version in $(jq -r '.items[].latestReleaseVersion' "${TEMP_DIR}/latest-versions.json")
 do
 	download_file "https://java.oraclecloud.com/javaReleases/${version}" "${TEMP_DIR}/release-${version}.json"
+	LICENSE_TYPE=$(jq -r '.licenseDetails.licenseType' "${TEMP_DIR}/release-${version}.json")
+	if [[ "$LICENSE_TYPE" = "OTN" ]]
+	then
+		echo "Skipping OTN licensed versions"
+		continue
+	fi
+
 	for JDK_URL in $(jq -r '.artifacts[].downloadUrl' "${TEMP_DIR}/release-${version}.json")
 	do
 		JDK_FILE=$(basename "${JDK_URL}")
@@ -159,3 +166,4 @@ do
 	download_and_parse "$version"
 done
 
+jq -s -S . "${METADATA_DIR}"/jdk-*.json > "${METADATA_DIR}/all.json"


### PR DESCRIPTION
The metadata line appears to have been inadvertently removed in https://github.com/joschi/java-metadata/pull/66/files#diff-0d35c769b71d47e45ebac5fa6101dbd3fabd6c1a6e855886f4c843f9ef96a735L134.

The OTN skip is because when specific versions are OTN licensed a token and an OCI region are needed to download, both of which can't be supplied( to my knowledge) through asdf.