### PR TITLE
fix: improve zulu regex to ignore zre links

### DIFF
--- a/bin/zulu.bash
+++ b/bin/zulu.bash
@@ -57,16 +57,13 @@ REGEX='s/^zulu([0-9+_.]{2,})-(?:(ca-crac|ca-fx-dbg|ca-fx|ca-hl|ca-dbg|ea-cp3|ca|
 INDEX_FILE="${TEMP_DIR}/index.html"
 download_file 'https://static.azul.com/zulu/bin/' "${INDEX_FILE}"
 
-ZULU_FILES=$(grep -o -E '<a href=".*/(zulu.+-(linux|macosx|win|solaris)_(musl_x64|musl_aarch64|x64|i686|aarch32hf|aarch32sf|aarch64|ppc64|sparcv9)\.(tar\.gz|zip|msi|dmg))">' "${INDEX_FILE}" | perl -pe 's#<a href=".*/(zulu[^/]+)">#$1#g' | sort -V)
+ZULU_FILES=$(grep -o -E '<a href=".*/(zulu[0-9]+.+-(linux|macosx|win|solaris)_(musl_x64|musl_aarch64|x64|i686|aarch32hf|aarch32sf|aarch64|ppc64|sparcv9)\.(tar\.gz|zip|msi|dmg))">' "${INDEX_FILE}" | perl -pe 's#<a href=".*/(zulu[^/]+)">#$1#g' | sort -V)
 for ZULU_FILE in ${ZULU_FILES}
 do
 	METADATA_FILE="${METADATA_DIR}/${ZULU_FILE}.json"
 	ZULU_ARCHIVE="${TEMP_DIR}/${ZULU_FILE}"
 	ZULU_URL="https://static.azul.com/zulu/bin/${ZULU_FILE}"
-	if [[ "${ZULU_FILE}" == *"zre"* ]]
-	then
-		echo  "Ignoring ${ZULU_FILE}"	    
-	elif [[ -f "${METADATA_FILE}" ]]
+	if [[ -f "${METADATA_FILE}" ]]
 	then
 		echo "Skipping ${ZULU_FILE}"
 	else


### PR DESCRIPTION
Fixes: https://github.com/joschi/java-metadata/issues/89

Looks like despite the [previous improvement](https://github.com/joschi/java-metadata/pull/42) to remove the zre build links, they've somehow made their way back in. This PR improves the grep expression to expect a number following "zulu" in order to avoid the zre or other potentially malformed names.

Before:
```
root@andrecloutier:~# grep -o -E '<a href=".*/(zulu.+-(linux|macosx|win|solaris)_(musl_x64|musl_aarch64|x64|i686|aarch32hf|aarch32sf|aarch64|ppc64|sparcv9)\.(tar\.gz|zip|msi|dmg))">' "${INDEX_FILE}" | perl -pe 's#<a href=".*/(zulu[^/]+)">#$1#g' | head
<a href="/zulu/bin/zre9.0.0.15-jre9.0.0-macosx_x64.dmg">
<a href="/zulu/bin/zre9.0.0.15-jre9.0.0-macosx_x64.tar.gz">
<a href="/zulu/bin/zre9.0.0.15-jre9.0.0-macosx_x64.zip">
<a href="/zulu/bin/zre9.0.0.15-jre9.0.0-win_x64.msi">
zulu10.1+11-jdk10-linux_i686.zip
zulu10.1+11-jdk10-linux_x64.tar.gz
zulu10.1+11-jdk10-macosx_x64.dmg
zulu10.1+11-jdk10-macosx_x64.tar.gz
zulu10.1+11-jdk10-macosx_x64.zip
zulu10.1+11-jdk10-win_i686.zip

root@andrecloutier:~# grep -o -E '<a href=".*/(zulu.+-(linux|macosx|win|solaris)_(musl_x64|musl_aarch64|x64|i686|aarch32hf|aarch32sf|aarch64|ppc64|sparcv9)\.(tar\.gz|zip|msi|dmg))">' "${INDEX_FILE}" | perl -pe 's#<a href=".*/(zulu[^/]+)">#$1#g' | wc -l
10494
```

After:
```
root@andrecloutier:~# grep -o -E '<a href=".*/(zulu[0-9]+.+-(linux|macosx|win|solaris)_(musl_x64|musl_aarch64|x64|i686|aarch32hf|aarch32sf|aarch64|ppc64|sparcv9)\.(tar\.gz|zip|msi|dmg))">' "${INDEX_FILE}" | perl -pe 's#<a href=".*/(zulu[^/]+)">#$1#g' | head
zulu10.1+11-jdk10-linux_i686.zip
zulu10.1+11-jdk10-linux_x64.tar.gz
zulu10.1+11-jdk10-macosx_x64.dmg
zulu10.1+11-jdk10-macosx_x64.tar.gz
zulu10.1+11-jdk10-macosx_x64.zip
zulu10.1+11-jdk10-win_i686.zip
zulu10.1+11-jdk10-win_x64.msi
zulu10.1+11-jdk10-win_x64.zip
zulu10.1+11-jdk10.0.0-linux_i686.zip
zulu10.1+11-jdk10.0.0-linux_x64.tar.gz

root@andrecloutier:~# grep -o -E '<a href=".*/(zulu[0-9]+.+-(linux|macosx|win|solaris)_(musl_x64|musl_aarch64|x64|i686|aarch32hf|aarch32sf|aarch64|ppc64|sparcv9)\.(tar\.gz|zip|msi|dmg))">' "${INDEX_FILE}" | perl -pe 's#<a href=".*/(zulu[^/]+)">#$1#g' | wc -l
10490
```